### PR TITLE
Add support for different environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,12 +163,13 @@ For ClojureScript, require `contentql.core` and `cljs.core.async`:
             [cljs.core.async :refer [<!]]))
 ```
 
-Then create a Contentful connection with `contentql/create-connection`. It receives three fields `:space-id`, `:access-token` and `:mode`. Use the space id and access token found on your Contentful dashboard. `:mode` should be either `:live` (for production environment) or `:preview` for (guess what, preview mode).
+Then create a Contentful connection with `contentql/create-connection`. It receives four fields `:space-id`, `:access-token`, `:mode` and `:environment`. Use the space id and access token found on your Contentful dashboard. `:mode` should be either `:live` (for production environment) or `:preview` for (guess what, preview mode). Lastly, `:environment` should be the environment you want to fetch data for.
 
 ```clojure
 (def config {:space-id "c3tshf2weg8y"
              :access-token "e87aea51cfd9193df88f5a1d1b842d9a43cc4f2b02366b7c0ead54fb1b0ad6d4"
-             :mode :live})
+             :mode :live
+             :environment "master"})
 
 (def conn (contentql/create-connection config))
 ```

--- a/src/cljc/contentql/core.cljc
+++ b/src/cljc/contentql/core.cljc
@@ -342,15 +342,17 @@
 ;; ------------------------------
 
 (defn create-connection
-  "Config is `{:space-id \"xxx\" :access-token \"xxx\" :mode :live}`
+  "Config is `{:space-id \"xxx\" :access-token \"xxx\" :mode :live :environment \"xxx\"}`
   `:mode` can be `:live` or `:preview`"
-  [{:keys [space-id access-token mode]}]
+  [{:keys [space-id access-token environment mode]}]
   (let [base-url (if (= mode :live)
                    "https://cdn.contentful.com"
                    "https://preview.contentful.com")
         space-url (str base-url
                        "/spaces/"
-                       space-id)
+                       space-id
+                       "/environments/"
+                       environment)
         entries-url (str space-url
                          "/entries?access_token="
                          access-token)


### PR DESCRIPTION
Since environments have been introduced and you can change between environments, this PR adds in support to fetch data from a specific environment (this adds in a new field called `environment`)